### PR TITLE
Implement apt installer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,6 +65,20 @@ jobs:
         with:
           method: ${{matrix.method}}
 
+      - name: Run the action on this runner with nvcc subpackage only (Linux)
+        if: runner.os == 'Linux' && matrix.method == 'network'
+        uses: ./
+        with:
+          method: ${{matrix.method}}
+          subPackages: '["nvcc"]'
+
+      - name: Run the action on this runner with nvcc subpackage only (Windows)
+        if: runner.os == 'Windows'
+        uses: ./
+        with:
+          method: ${{matrix.method}}
+          subPackages: '["nvcc"]'
+
       - name: Test if nvcc is available
         run: nvcc -V
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Default: `'[]'`.
 
 **Optional**
 Installation method, can be either `'local'` or `'network'`.
-- `'local'` downloads the entire installer with all packages and runs that (you can still only install certain packages with subPackages on Windows). 
+
+- `'local'` downloads the entire installer with all packages and runs that (you can still only install certain packages with `sub-packages` on Windows).
 - `'network'` downloads a smaller executable which only downloads necessary packages which you can define in subPackages.
 
 Default: `'local'`.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This action installs the [NVIDIA® CUDA® Toolkit](https://developer.nvidia.com/
 
 ### `cuda`
 
-**Optional** The CUDA version to install.
+**Optional** The CUDA version to install. View `src/link/windowsLinks.ts` and `src/link/linuxLinks.ts` for available versions.
 
 Default: `'11.2.2'`.
 
 ### `subPackages`
 
-**NOTE: For now this ONLY works on Windows platforms**
+**NOTE: On Linux this only works with the 'network' method [view details](#method)**
 
 **Optional**
 If set, only the specified CUDA subpackages will be installed.
@@ -22,10 +22,10 @@ Default: `'[]'`.
 
 ### `method`
 
-**NOTE: Right now 'network' is not implemented on Linux runners**
-
 **Optional**
-Installation method, can be either 'local' or 'network'. 'local' downloads the entire installer with all packages and runs that (you can still only install certain packages with subPackages). 'network' downloads a smaller executable which only downloads necessary packages which you can define in subPackages.
+Installation method, can be either `'local'` or `'network'`.
+- `'local'` downloads the entire installer with all packages and runs that (you can still only install certain packages with subPackages on Windows). 
+- `'network'` downloads a smaller executable which only downloads necessary packages which you can define in subPackages.
 
 Default: `'local'`.
 

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
     required: false
     default: '11.2.2'
   sub-packages:
-    description: '(Windows only for now) Only installs specified subpackages, must be in the form of a JSON array. For example, if you only want to install nvcc and visual studio integration: ["nvcc", "visual_studio_integration"] double quotes required!'
+    description: 'Only installs specified subpackages, must be in the form of a JSON array. For example, if you only want to install nvcc and visual studio integration: ["nvcc", "visual_studio_integration"] double quotes required! Note that if you want to use this on Linux, ''network'' method MUST be used.'
     required: false
     default: '[]'
   method:
-    description: "('network' is not yet implemented on Linux). Installation method, can be either 'local' or 'network'. 'local' downloads the entire installer with all packages and runs that (you can still only install certain packages with subPackages). 'network' downloads a smaller executable which only downloads necessary packages which you can define in subPackages"
+    description: "('network' is not yet implemented on Linux). Installation method, can be either 'local' or 'network'. 'local' downloads the entire installer with all packages and runs that (you can still only install certain packages with sub-packages on Windows). 'network' downloads a smaller executable which only downloads necessary packages which you can define in subPackages"
     required: false
     default: 'local'
   linux-local-args:

--- a/src/aptInstaller.ts
+++ b/src/aptInstaller.ts
@@ -56,7 +56,7 @@ export async function aptInstall(
   } else {
     // Only install specified packages
     const versionedSubPackages = subPackages.map(
-      subPackage => `${subPackage}-${version.major}-${version.minor}`
+      subPackage => `cuda-${subPackage}-${version.major}-${version.minor}`
     )
     core.debug(`Only install subpackages: ${versionedSubPackages}`)
     return await exec(`sudo apt-get -y install`, versionedSubPackages)

--- a/src/aptInstaller.ts
+++ b/src/aptInstaller.ts
@@ -55,7 +55,10 @@ export async function aptInstall(
     return await exec(`sudo apt-get -y install`, [packageName])
   } else {
     // Only install specified packages
-    core.debug(`Only install subpackages: ${subPackages}`)
-    return await exec(`sudo apt-get -y install`, subPackages)
+    const versionedSubPackages = subPackages.map(
+      subPackage => `${subPackage}-${version.major}-${version.minor}`
+    )
+    core.debug(`Only install subpackages: ${versionedSubPackages}`)
+    return await exec(`sudo apt-get -y install`, versionedSubPackages)
   }
 }

--- a/src/aptInstaller.ts
+++ b/src/aptInstaller.ts
@@ -17,10 +17,7 @@ export async function aptSetup(version: SemVer): Promise<void> {
     )
   }
   core.debug(`Setup packages for ${version}`)
-  const ubuntuVersion: string = await execReturnOutput('lsb_release', [
-    '-',
-    'sr'
-  ])
+  const ubuntuVersion: string = await execReturnOutput('lsb_release', ['-sr'])
   const ubuntuVersionNoDot = ubuntuVersion.replace('.', '')
   const pinFilename = `cuda-ubuntu${ubuntuVersionNoDot}.pin`
   const pinUrl = `https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${ubuntuVersionNoDot}/x86_64/${pinFilename}`

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -2,9 +2,11 @@ import {exec} from '@actions/exec'
 import * as core from '@actions/core'
 import {getOs, OSType} from './platform'
 import * as artifact from '@actions/artifact'
+import {SemVer} from 'semver'
 
 export async function install(
   executablePath: string,
+  version: SemVer,
   subPackagesArray: string[],
   linuxLocalArgsArray: string[]
 ): Promise<void> {
@@ -43,10 +45,14 @@ export async function install(
       command = executablePath
       // Install silently
       installArgs = ['-s']
+      // Add subpackages to command args (if any)
+      installArgs = installArgs.concat(
+        subPackages.map(
+          subPackage => `${subPackage}_${version.major}.${version.minor}`
+        )
+      )
       break
   }
-  // Add subpackages to command args (if any)
-  installArgs = installArgs.concat(subPackages)
 
   // Run installer
   try {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -47,9 +47,13 @@ export async function install(
       installArgs = ['-s']
       // Add subpackages to command args (if any)
       installArgs = installArgs.concat(
-        subPackages.map(
-          subPackage => `${subPackage}_${version.major}.${version.minor}`
-        )
+        subPackages.map(subPackage => {
+          // Display driver sub package name is not dependent on version
+          if (subPackage === 'Display.Driver') {
+            return subPackage
+          }
+          return `${subPackage}_${version.major}.${version.minor}`
+        })
       )
       break
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import {aptInstall, aptSetup, useApt} from './aptInstaller'
 import {Method, parseMethod} from './method'
 import {updatePath} from './updatePath'
 import {getVersion} from './version'
+import {getOs, OSType} from './platform'
 
 async function run(): Promise<void> {
   try {
@@ -44,6 +45,17 @@ async function run(): Promise<void> {
       const errString = `Error parsing input 'linux-local-args' to a JSON string array: ${linuxLocalArgs}`
       core.debug(errString)
       throw new Error(errString)
+    }
+
+    // Check if subPackages are specified in 'local' method on Linux
+    if (
+      methodParsed === 'local' &&
+      subPackagesArray.length > 0 &&
+      (await getOs()) === OSType.linux
+    ) {
+      throw new Error(
+        `Subpackages on 'local' method is not supported on Linux, use 'network' instead`
+      )
     }
 
     // Linux network install (uses apt repository)

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,12 @@ async function run(): Promise<void> {
       const executablePath: string = await download(version, methodParsed)
 
       // Install
-      await install(executablePath, subPackagesArray, linuxLocalArgsArray)
+      await install(
+        executablePath,
+        version,
+        subPackagesArray,
+        linuxLocalArgsArray
+      )
     }
 
     // Add CUDA environment variables to GitHub environment variables

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,9 +50,9 @@ async function run(): Promise<void> {
     const useAptInstall = await useApt(methodParsed)
     if (useAptInstall) {
       // Setup aptitude repos
-      const packageName = await aptSetup(version)
+      await aptSetup(version)
       // Install packages
-      const installResult = await aptInstall(packageName, subPackagesArray)
+      const installResult = await aptInstall(version, subPackagesArray)
       core.debug(`Install result: ${installResult}`)
     } else {
       // Download
@@ -63,7 +63,7 @@ async function run(): Promise<void> {
     }
 
     // Add CUDA environment variables to GitHub environment variables
-    await updatePath(version, useAptInstall)
+    await updatePath(version)
 
     core.setOutput('cuda', cuda)
   } catch (error) {

--- a/src/runCommand.ts
+++ b/src/runCommand.ts
@@ -1,0 +1,24 @@
+import {exec} from '@actions/exec'
+import * as core from '@actions/core'
+
+export async function execReturnOutput(
+  command: string,
+  args: string[] = []
+): Promise<string> {
+  let result = ''
+  const execOptions = {
+    listeners: {
+      stdout: (data: Buffer) => {
+        result += data.toString()
+      },
+      stderr: (data: Buffer) => {
+        core.debug(`Error: ${data.toString()}`)
+      }
+    }
+  }
+  const exitCode = await exec(command, args, execOptions)
+  if (exitCode) {
+    core.debug(`Error executing: ${command}. Exit code: ${exitCode}`)
+  }
+  return result.trim()
+}

--- a/src/updatePath.ts
+++ b/src/updatePath.ts
@@ -3,18 +3,11 @@ import {getOs, OSType} from './platform'
 import * as path from 'path'
 import * as core from '@actions/core'
 
-export async function updatePath(
-  version: SemVer,
-  useApt: boolean
-): Promise<void> {
+export async function updatePath(version: SemVer): Promise<void> {
   let cudaPath: string
   switch (await getOs()) {
     case OSType.linux:
-      if (useApt) {
-        cudaPath = `/usr/local/cuda`
-      } else {
-        cudaPath = `/usr/local/cuda-${version.major}.${version.minor}`
-      }
+      cudaPath = `/usr/local/cuda-${version.major}.${version.minor}`
       break
     case OSType.windows:
       cudaPath = `C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v${version.major}.${version.minor}`


### PR DESCRIPTION
This adds the initial apt install method, which is needed to only install certain subpackages on Linux

Fixes #2