### PR TITLE
Export CUDA_PATH to CUDA_PATH_V{X}_{Y}

### DIFF
--- a/src/updatePath.ts
+++ b/src/updatePath.ts
@@ -17,6 +17,7 @@ export async function updatePath(version: SemVer): Promise<string> {
   core.exportVariable('CUDA_PATH', cudaPath)
   core.debug(`Cuda path vx_y: ${cudaPath}`)
   // Export $CUDA_PATH_VX_Y
+  core.exportVariable(`CUDA_PATH_V${version.major}_${version.minor}`, cudaPath)
   core.exportVariable(
     'CUDA_PATH_VX_Y',
     `CUDA_PATH_V${version.major}_${version.minor}`


### PR DESCRIPTION
`CUDA_PATH_V${major}_${minor}` environment variable is now explicitly set to the value of `cuda_path`.

This fixes #1 

Should be noted that I did not remove the current `'CUDA_PATH_VX_Y'` being set to `CUDA_PATH_V${version.major}_${version.minor}`, in the case that anyone relied on that.