### PR TITLE
Fix GitHub CI OS matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019, ubuntu-20.04, ubuntu-18.04]
+        os: [windows-2019, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
         method: [local, network]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
- Windows 2016 is not supported anymore, so remove it
- Add ubuntu 22.04 to the OS matrix