### PR TITLE
Added all missing 11.x.x versions. Support 2-digit versions.

### DIFF
--- a/src/links/linux-links.ts
+++ b/src/links/linux-links.ts
@@ -13,8 +13,28 @@ export class LinuxLinks extends AbstractLinks {
     // Map of cuda SemVer version to download URL
     this.cudaVersionToURL = new Map([
       [
+        '11.8', // Latest version of 11.8.x
+        'https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run'
+      ], 
+      [
+        '11.8.0',
+        'https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run'
+      ], 
+      [
+        '11.7', // Latest version of 11.7.x
+        'https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux.run'
+      ],
+      [
+        '11.7.1',
+        'https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux.run'
+      ],
+      [
         '11.7.0',
         'https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda_11.7.0_515.43.04_linux.run'
+      ],
+      [
+        '11.6', // Latest version of 11.6.x
+        'https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run'
       ],
       [
         '11.6.2',
@@ -29,6 +49,10 @@ export class LinuxLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux.run'
       ],
       [
+        '11.5', // Latest version of 11.5.x
+        'https://developer.download.nvidia.com/compute/cuda/11.5.2/local_installers/cuda_11.5.2_495.29.05_linux.run'
+      ],
+      [
         '11.5.2',
         'https://developer.download.nvidia.com/compute/cuda/11.5.2/local_installers/cuda_11.5.2_495.29.05_linux.run'
       ],
@@ -39,6 +63,14 @@ export class LinuxLinks extends AbstractLinks {
       [
         '11.5.0',
         'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run'
+      ],
+      [
+        '11.4', // Latest version of 11.4.x
+        'https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux.run'
+      ],
+      [
+        '11.4.4',
+        'https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux.run'
       ],
       [
         '11.4.3',
@@ -57,12 +89,20 @@ export class LinuxLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux.run'
       ],
       [
+        '11.3', // Latest version of 11.3.x
+        'https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run'
+      ],
+      [
         '11.3.1',
         'https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run'
       ],
       [
         '11.3.0',
         'https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux.run'
+      ],
+      [
+        '11.2', // Latest version of 11.2.x
+        'https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run'
       ],
       [
         '11.2.2',
@@ -77,12 +117,36 @@ export class LinuxLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.27.04_linux.run'
       ],
       [
+        '11.1', // Latest version of 11.1.x
+        'https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux.run'
+      ],
+      [
         '11.1.1',
         'https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux.run'
       ],
       [
+        '11.1.0',
+        'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux.run'
+      ],
+      [
+        '11.0', // Latest version of 11.0.x
+        'https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run'
+      ],
+      [
         '11.0.3',
         'https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run'
+      ],
+      [
+        '11.0.2',
+        'http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'
+      ],
+      [
+        '11.0.1',
+        'https://developer.download.nvidia.com/compute/cuda/11.0.1/local_installers/cuda_11.0.1_450.36.06_linux.run'
+      ],
+      [
+        '11.0.0',
+        'http://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'
       ],
       [
         '10.2.89',

--- a/src/links/windows-links.ts
+++ b/src/links/windows-links.ts
@@ -2,19 +2,8 @@ import {AbstractLinks} from './links'
 import {SemVer} from 'semver'
 
 // # Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern :(
-// $CUDA_KNOWN_URLS = @{
-//     "8.0.44" = "http://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
-//     "8.0.61" = "http://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
-//     "9.0.176" = "http://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
-//     "9.1.85" = "http://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
-//     "9.2.148" = "http://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
-//     "10.0.130" = "http://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
-//     "10.1.105" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
-//     "10.1.168" = "http://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
-//     "10.1.243" = "http://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
-//     "10.2.89" = "http://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
-//     "11.0.167" = "http://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe"
-// }
+// cuda toolkit downloads here:
+// https://developer.nvidia.com/cuda-toolkit-archive
 
 /**
  * Singleton class for windows links.
@@ -25,8 +14,28 @@ export class WindowsLinks extends AbstractLinks {
 
   private cudaVersionToNetworkUrl: Map<string, string> = new Map([
     [
+      '11.8', // Latest version of 11.8.x
+      'https://developer.download.nvidia.com/compute/cuda/11.8.0/network_installers/cuda_11.8.0_windows_network.exe'
+    ],
+    [
+      '11.8.0',
+      'https://developer.download.nvidia.com/compute/cuda/11.8.0/network_installers/cuda_11.8.0_windows_network.exe'
+    ],
+    [
+      '11.7', // Latest version of 11.7.x
+      'https://developer.download.nvidia.com/compute/cuda/11.7.1/network_installers/cuda_11.7.1_windows_network.exe'
+    ],
+    [
+      '11.7.1',
+      'https://developer.download.nvidia.com/compute/cuda/11.7.1/network_installers/cuda_11.7.1_windows_network.exe'
+    ],
+    [
       '11.7.0',
       'https://developer.download.nvidia.com/compute/cuda/11.7.0/network_installers/cuda_11.7.0_windows_network.exe'
+    ],
+    [
+      '11.6', // Latest version of 11.6.x
+      'https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe'
     ],
     [
       '11.6.2',
@@ -41,6 +50,10 @@ export class WindowsLinks extends AbstractLinks {
       'https://developer.download.nvidia.com/compute/cuda/11.6.0/network_installers/cuda_11.6.0_windows_network.exe'
     ],
     [
+      '11.5', // Latest version of 11.5.x
+      'https://developer.download.nvidia.com/compute/cuda/11.5.2/network_installers/cuda_11.5.2_win10_network.exe'
+    ],
+    [
       '11.5.2',
       'https://developer.download.nvidia.com/compute/cuda/11.5.2/network_installers/cuda_11.5.2_windows_network.exe'
     ],
@@ -49,8 +62,12 @@ export class WindowsLinks extends AbstractLinks {
       'https://developer.download.nvidia.com/compute/cuda/11.5.1/network_installers/cuda_11.5.1_windows_network.exe'
     ],
     [
-      '11.5.0',
-      'https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe'
+      '11.5',
+      'https://developer.download.nvidia.com/compute/cuda/11.5.2/network_installers/cuda_11.5.2_windows_network.exe'
+    ],
+    [
+      '11.4', // Latest version of 11.4.x
+      'https://developer.download.nvidia.com/compute/cuda/11.4.3/network_installers/cuda_11.4.3_win10_network.exe'
     ],
     [
       '11.4.3',
@@ -69,12 +86,20 @@ export class WindowsLinks extends AbstractLinks {
       'https://developer.download.nvidia.com/compute/cuda/11.4.0/network_installers/cuda_11.4.0_win10_network.exe'
     ],
     [
+      '11.3',  // Latest version of 11.3.x
+      'https://developer.download.nvidia.com/compute/cuda/11.3.1/network_installers/cuda_11.3.1_win10_network.exe'
+    ],
+    [
       '11.3.1',
       'https://developer.download.nvidia.com/compute/cuda/11.3.1/network_installers/cuda_11.3.1_win10_network.exe'
     ],
     [
       '11.3.0',
       'https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe'
+    ],
+    [
+      '11.2',  // Latest version of 11.2.x
+      'https://developer.download.nvidia.com/compute/cuda/11.2.2/network_installers/cuda_11.2.2_win10_network.exe'
     ],
     [
       '11.2.2',
@@ -89,12 +114,40 @@ export class WindowsLinks extends AbstractLinks {
       'https://developer.download.nvidia.com/compute/cuda/11.2.0/network_installers/cuda_11.2.0_win10_network.exe'
     ],
     [
+      '11.1',  // Latest version of 11.1.x
+      'https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe'
+    ],
+    [
       '11.1.1',
       'https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe'
     ],
     [
+      '11.1.0',
+      'https://developer.download.nvidia.com/compute/cuda/11.1.0/network_installers/cuda_11.1.0_win10_network.exe'
+    ],
+    [
+      '11.0',  // Latest version of 11.0.x
+      'https://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe'
+    ],
+    [
       '11.0.3',
       'https://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe'
+    ],
+    [
+      '11.0',  // Latest version of 11.0.x
+      'https://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe'
+    ],
+    [
+      '11.0.2',
+      'https://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe'
+    ],
+    [
+      '11.0.1',
+      'https://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe'
+    ],
+    [
+      '11.0.0',
+      'https://developer.download.nvidia.com/compute/cuda/11.0.0/network_installers/cuda_11.0.0_win10_network.exe'
     ],
     [
       '10.2.89',
@@ -124,8 +177,28 @@ export class WindowsLinks extends AbstractLinks {
     // Map of cuda SemVer version to download URL
     this.cudaVersionToURL = new Map([
       [
+        '11.8', // Latest version of 11.8.x
+        'https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe'
+      ],
+      [
+        '11.8.0',
+        'https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe'
+      ],
+      [
+        '11.7', // Latest version of 11.7.x
+        'https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_516.94_windows.exe'
+      ],
+      [
+        '11.7.1',
+        'https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_516.94_windows.exe'
+      ],
+      [
         '11.7.0',
         'https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda_11.7.0_516.01_windows.exe'
+      ],
+      [
+        '11.6', // Latest version of 11.6.x
+        'https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_511.65_windows.exe'
       ],
       [
         '11.6.2',
@@ -140,6 +213,10 @@ export class WindowsLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
       ],
       [
+        '11.5', // Latest version of 11.5.x
+        'https://developer.download.nvidia.com/compute/cuda/11.5.2/local_installers/cuda_11.5.2_496.13_windows.exe'
+      ],
+      [
         '11.5.2',
         'https://developer.download.nvidia.com/compute/cuda/11.5.2/local_installers/cuda_11.5.2_496.13_windows.exe'
       ],
@@ -152,7 +229,11 @@ export class WindowsLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_496.13_win10.exe'
       ],
       [
-        '11.4.3',
+        '11.4',
+        'https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_472.50_win10.exe'
+      ],
+      [
+        '11.4.3', // Latest version of 11.4.x
         'https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_472.50_win10.exe'
       ],
       [
@@ -168,12 +249,20 @@ export class WindowsLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_471.11_win10.exe'
       ],
       [
+        '11.3', // Latest version of 11.3.x
+        'https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.89_win10.exe'
+      ],
+      [
         '11.3.1',
         'https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.89_win10.exe'
       ],
       [
         '11.3.0',
         'https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.89_win10.exe'
+      ],
+      [
+        '11.2', // Latest version of 11.2.x
+        'https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_461.33_win10.exe'
       ],
       [
         '11.2.2',
@@ -188,12 +277,32 @@ export class WindowsLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.89_win10.exe'
       ],
       [
+        '11.1', // Latest version of 11.1.x
+        'https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_456.81_win10.exe'
+      ],
+      [
         '11.1.1',
         'https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_456.81_win10.exe'
       ],
       [
-        '11.0.3',
+        '11.1.0',
+        'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_456.43_win10.exe'
+      ],
+      [
+        '11.0.3', // Latest version of 11.0.x
         'https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_451.82_win10.exe'
+      ],
+      [
+        '11.0.2',
+        'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_451.48_win10.exe'
+      ],
+      [
+        '11.0.1',
+        'https://developer.download.nvidia.com/compute/cuda/11.0.1/local_installers/cuda_11.0.1_451.22_win10.exe'
+      ],
+      [
+        '11.0.0',
+        'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_451.48_win10.exe'
       ],
       [
         '10.2.89',


### PR DESCRIPTION
- [FIX] Added all missing 11.x.x versions for Windows and Linux
  - e.g. 11.3.0 was missing in Windows.
- [NEW] Support 2-digit versions and use latest release of that version
  - can now also specify versions as 11.0, 11.7, etc.
  - 11.7 -> 11.7.1 which is latest  instead of 11.7.0 which was the first release)