### PR TITLE
replaces the set-output command

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,8 +32,9 @@ jobs:
       # npm cache
       - name: Get npm cache directory
         id: npm-cache-dir
+        shell: bash
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
         with:


### PR DESCRIPTION
`set-output` command will be disabled
For more [For more information](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
using `bash` to run with the same command