### PR TITLE
Update action to node 20

### DIFF
--- a/.github/workflows/Check-dist.yml
+++ b/.github/workflows/Check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js
         uses: actions/setup-node@v4.0.2
         with:
-          node-version: 20.x
+          node-version-file: 'package.json'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/Check-dist.yml
+++ b/.github/workflows/Check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
-        uses: actions/setup-node@v4.0.1
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v4.0.2
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: 'log.txt'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: dist/index.js
 branding:
   icon: box

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Jimver/cuda-toolkit#readme",
   "volta": {
-    "node": "16.19.1"
+    "node": "20.12.2"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Hi!

Thanks for your great GitHub action! I really enjoy using it!

I am seeing the same warning as mentioned in #311 since actions require node 20 now (see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

Simply changing the node version in `action.yml` should resolve this.

Best, Roman