### PR TITLE
feat: add cuda 12.5.1 & 12.6.0 & 12.6.1 & 12.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action installs the [NVIDIA® CUDA® Toolkit](https://developer.nvidia.com/
 
 **Optional** The CUDA version to install. View `src/link/windows-links.ts` and `src/link/linux-links.ts` for available versions.
 
-Default: `'12.5.0'`.
+Default: `'12.6.1'`.
 
 ### `sub-packages`
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   cuda:
     description: 'Cuda version'
     required: false
-    default: '12.5.0'
+    default: '12.6.1'
   sub-packages:
     description: 'Only installs specified subpackages, must be in the form of a JSON array. For example, if you only want to install nvcc and visual studio integration: ["nvcc", "visual_studio_integration"] double quotes required! Note that if you want to use this on Linux, ''network'' method MUST be used.'
     required: false

--- a/src/links/linux-links.ts
+++ b/src/links/linux-links.ts
@@ -17,6 +17,10 @@ export class LinuxLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.35.03_linux.run'
       ],
       [
+        '12.5.1',
+        'https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda_12.5.1_555.42.06_linux.run'
+      ],
+      [
         '12.5.0',
         'https://developer.download.nvidia.com/compute/cuda/12.5.0/local_installers/cuda_12.5.0_555.42.02_linux.run'
       ],

--- a/src/links/linux-links.ts
+++ b/src/links/linux-links.ts
@@ -13,6 +13,10 @@ export class LinuxLinks extends AbstractLinks {
     // Map of cuda SemVer version to download URL
     this.cudaVersionToURL = new Map([
       [
+        '12.6.2',
+        'https://developer.download.nvidia.com/compute/cuda/12.6.2/local_installers/cuda_12.6.2_560.35.03_linux.run'
+      ],
+      [
         '12.6.1',
         'https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.35.03_linux.run'
       ],

--- a/src/links/linux-links.ts
+++ b/src/links/linux-links.ts
@@ -13,6 +13,10 @@ export class LinuxLinks extends AbstractLinks {
     // Map of cuda SemVer version to download URL
     this.cudaVersionToURL = new Map([
       [
+        '12.6.1',
+        'https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.35.03_linux.run'
+      ],
+      [
         '12.5.0',
         'https://developer.download.nvidia.com/compute/cuda/12.5.0/local_installers/cuda_12.5.0_555.42.02_linux.run'
       ],

--- a/src/links/linux-links.ts
+++ b/src/links/linux-links.ts
@@ -17,6 +17,10 @@ export class LinuxLinks extends AbstractLinks {
         'https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.35.03_linux.run'
       ],
       [
+        '12.6.0',
+        'https://developer.download.nvidia.com/compute/cuda/12.6.0/local_installers/cuda_12.6.0_560.28.03_linux.run'
+      ],
+      [
         '12.5.1',
         'https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda_12.5.1_555.42.06_linux.run'
       ],

--- a/src/links/windows-links.ts
+++ b/src/links/windows-links.ts
@@ -29,6 +29,10 @@ export class WindowsLinks extends AbstractLinks {
       'https://developer.download.nvidia.com/compute/cuda/12.6.1/network_installers/cuda_12.6.1_windows_network.exe'
     ],
     [
+      '12.6.0',
+      'https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe'
+    ],
+    [
       '12.5.1',
       'https://developer.download.nvidia.com/compute/cuda/12.5.1/network_installers/cuda_12.5.1_windows_network.exe'
     ],
@@ -206,6 +210,10 @@ export class WindowsLinks extends AbstractLinks {
       [
         '12.6.1',
         'https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.94_windows.exe'
+      ],
+      [
+        '12.6.0',
+        'https://developer.download.nvidia.com/compute/cuda/12.6.0/local_installers/cuda_12.6.0_560.76_windows.exe'
       ],
       [
         '12.5.1',

--- a/src/links/windows-links.ts
+++ b/src/links/windows-links.ts
@@ -29,6 +29,10 @@ export class WindowsLinks extends AbstractLinks {
       'https://developer.download.nvidia.com/compute/cuda/12.6.1/network_installers/cuda_12.6.1_windows_network.exe'
     ],
     [
+      '12.5.1',
+      'https://developer.download.nvidia.com/compute/cuda/12.5.1/network_installers/cuda_12.5.1_windows_network.exe'
+    ],
+    [
       '12.5.0',
       'https://developer.download.nvidia.com/compute/cuda/12.5.0/network_installers/cuda_12.5.0_windows_network.exe'
     ],
@@ -202,6 +206,10 @@ export class WindowsLinks extends AbstractLinks {
       [
         '12.6.1',
         'https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.94_windows.exe'
+      ],
+      [
+        '12.5.1',
+        'https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda_12.5.1_555.85_windows.exe'
       ],
       [
         '12.5.0',

--- a/src/links/windows-links.ts
+++ b/src/links/windows-links.ts
@@ -25,6 +25,10 @@ export class WindowsLinks extends AbstractLinks {
 
   private cudaVersionToNetworkUrl: Map<string, string> = new Map([
     [
+      '12.6.1',
+      'https://developer.download.nvidia.com/compute/cuda/12.6.1/network_installers/cuda_12.6.1_windows_network.exe'
+    ],
+    [
       '12.5.0',
       'https://developer.download.nvidia.com/compute/cuda/12.5.0/network_installers/cuda_12.5.0_windows_network.exe'
     ],
@@ -195,6 +199,10 @@ export class WindowsLinks extends AbstractLinks {
     super()
     // Map of cuda SemVer version to download URL
     this.cudaVersionToURL = new Map([
+      [
+        '12.6.1',
+        'https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.94_windows.exe'
+      ],
       [
         '12.5.0',
         'https://developer.download.nvidia.com/compute/cuda/12.5.0/local_installers/cuda_12.5.0_555.85_windows.exe'

--- a/src/links/windows-links.ts
+++ b/src/links/windows-links.ts
@@ -25,6 +25,10 @@ export class WindowsLinks extends AbstractLinks {
 
   private cudaVersionToNetworkUrl: Map<string, string> = new Map([
     [
+      '12.6.2',
+      'https://developer.download.nvidia.com/compute/cuda/12.6.2/network_installers/cuda_12.6.2_windows_network.exe'
+    ],
+    [
       '12.6.1',
       'https://developer.download.nvidia.com/compute/cuda/12.6.1/network_installers/cuda_12.6.1_windows_network.exe'
     ],
@@ -207,6 +211,10 @@ export class WindowsLinks extends AbstractLinks {
     super()
     // Map of cuda SemVer version to download URL
     this.cudaVersionToURL = new Map([
+      [
+        '12.6.2',
+        'https://developer.download.nvidia.com/compute/cuda/12.6.2/local_installers/cuda_12.6.2_560.94_windows.exe'
+      ],
       [
         '12.6.1',
         'https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.94_windows.exe'


### PR DESCRIPTION
Add CUDA version 12.5.1 & 12.6.0 & 12.6.1 & 12.6.2

If someone wants to use this PR as a temporary solution, try replacing `Jimver/cuda-toolkit@x.x.x` with `MZWNET/cuda-toolkit@mod`.
