### PR TITLE
CUDA 12.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action installs the [NVIDIA® CUDA® Toolkit](https://developer.nvidia.com/
 
 **Optional** The CUDA version to install. View `src/link/windows-links.ts` and `src/link/linux-links.ts` for available versions.
 
-Default: `'12.8.0'`.
+Default: `'12.8.1'`.
 
 ### `sub-packages`
 
@@ -88,7 +88,7 @@ The path where cuda is installed (same as `CUDA_PATH` in `GITHUB_ENV`).
 
 ```yaml
 steps:
-- uses: Jimver/cuda-toolkit@v0.2.21
+- uses: Jimver/cuda-toolkit@v0.2.22
   id: cuda-toolkit
   with:
     cuda: '12.5.0'

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   cuda:
     description: 'Cuda version'
     required: false
-    default: '12.8.0'
+    default: '12.8.1'
   sub-packages:
     description: 'Only installs specified subpackages, must be in the form of a JSON array. For example, if you only want to install nvcc and visual studio integration: ["nvcc", "visual_studio_integration"] double quotes required! Note that if you want to use this on Linux, ''network'' method MUST be used.'
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cuda-toolkit",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cuda-toolkit",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuda-toolkit",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "GitHub Action to install the NVIDIA CUDA Toolkit",
   "main": "lib/main.js",
   "scripts": {

--- a/src/links/linux-links.ts
+++ b/src/links/linux-links.ts
@@ -15,6 +15,10 @@ export class LinuxLinks extends AbstractLinks {
     // Map of cuda SemVer version to download URL
     this.cudaVersionToURL = new Map([
       [
+        '12.8.1',
+        'https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run'
+      ],
+      [
         '12.8.0',
         'https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_570.86.10_linux.run'
       ],

--- a/src/links/windows-links.ts
+++ b/src/links/windows-links.ts
@@ -224,6 +224,10 @@ export class WindowsLinks extends AbstractLinks {
     // Map of cuda SemVer version to download URL
     this.cudaVersionToURL = new Map([
       [
+        '12.8.1',
+        'https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_572.61_windows.exe'
+      ],
+      [
         '12.8.0',
         'https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_571.96_windows.exe'
       ],

--- a/src/links/windows-links.ts
+++ b/src/links/windows-links.ts
@@ -25,6 +25,10 @@ export class WindowsLinks extends AbstractLinks {
 
   private cudaVersionToNetworkUrl: Map<string, string> = new Map([
     [
+      '12.8.1',
+      'https://developer.download.nvidia.com/compute/cuda/12.8.1/network_installers/cuda_12.8.1_windows_network.exe'
+    ],
+    [
       '12.8.0',
       'https://developer.download.nvidia.com/compute/cuda/12.8.0/network_installers/cuda_12.8.0_windows_network.exe'
     ],


### PR DESCRIPTION
This pull request includes several updates to support the new CUDA version `12.8.1`. The main changes involve updating the default CUDA version in various configuration files and adding download URLs for the new version in the link files.

Updates to default CUDA version:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11): Updated the default CUDA version from `12.8.0` to `12.8.1`.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L8-R8): Updated the default CUDA version from `12.8.0` to `12.8.1`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.2.21` to `0.2.22`.

Addition of new CUDA version URLs:

* [`src/links/linux-links.ts`](diffhunk://#diff-9846d9838f9fc5345a4457ef2bca2cb337074649e43d01cb6590dc96519ee811R17-R20): Added download URL for CUDA version `12.8.1` for Linux.
* [`src/links/windows-links.ts`](diffhunk://#diff-aba835ff33fd73b95a6f60910e505c8a55e4f3a89f900c3be63e50e605ad61a9R27-R30): Added download URLs for CUDA version `12.8.1` for Windows (network and local installers). [[1]](diffhunk://#diff-aba835ff33fd73b95a6f60910e505c8a55e4f3a89f900c3be63e50e605ad61a9R27-R30) [[2]](diffhunk://#diff-aba835ff33fd73b95a6f60910e505c8a55e4f3a89f900c3be63e50e605ad61a9R226-R229)

merge it @Jimver 