### PR TITLE
fix #381

### DIFF
--- a/.github/workflows/Check-dist.yml
+++ b/.github/workflows/Check-dist.yml
@@ -54,5 +54,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
-          name: dist
+          name: dist-${{ github.job }}
           path: dist/
+


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/Check-dist.yml` file. The change modifies the artifact name to include the job name for better identification.

* [`.github/workflows/Check-dist.yml`](diffhunk://#diff-844a66abc391cbcb5e1fbdb51ccabe27e6b6586d958ad7c138d749cf4a087320L57-R59): Changed the artifact name from `dist` to `dist-${{ github.job }}` to include the job name in the artifact name.