### PR TITLE
changing default for use-local-cache to false (GH runners run out of disk space)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
     description:
       'Use local cache to cache downloaded installer on the local runner'
     required: false
-    default: 'true'
+    default: 'false'
   log-file-suffix:
     description: 'Suffix of log file name in artifact'
     required: false


### PR DESCRIPTION
Changing the default value of use-local-cache to false to solve this issue, which seems to happen on all runs now: https://github.com/Jimver/cuda-toolkit/issues/386

Example run that works with use-local-cache: false https://github.com/tbarron-xyz/cuda-factorization/actions/runs/18314747208

Example run that fails without it https://github.com/tbarron-xyz/cuda-factorization/actions/runs/18314278974